### PR TITLE
Made LazPackager compilable again with fpc & Lazarus stable versions.…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 lib
+backup
+doc-devel

--- a/README.md
+++ b/README.md
@@ -51,3 +51,10 @@ Does it work yet?
 -----------------
 95%. Should work for most simple projects out of the box and with
 a few tweaks to the templates for all others too.
+
+NB by Thierry Andriamirado:
+---------------------------
+I concocted and delivered this maintenance version for practical reasons,
+so that LazPackager continues to work as Lazarus evolves, and why not, to make
+it evolve. Thanks go to Bernd Kreuss for this useful project.
+

--- a/lazpackager.lpk
+++ b/lazpackager.lpk
@@ -1,19 +1,14 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
   <Package Version="4">
     <Name Value="LazPackager"/>
+    <Type Value="DesignTime"/>
     <Author Value="Bernd Kreuss"/>
     <CompilerOptions>
       <Version Value="11"/>
       <SearchPaths>
         <UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/>
       </SearchPaths>
-      <Other>
-        <CompilerMessages>
-          <MsgFileName Value=""/>
-        </CompilerMessages>
-        <CompilerPath Value="$(CompPath)"/>
-      </Other>
     </CompilerOptions>
     <Description Value="Build a binary Debian (.deb) package from the current project or create a Debian source package and sign and upload to a Launchpad PPA automatically."/>
     <License Value="This source is free software; you can redistribute it and/or modify it
@@ -30,11 +25,11 @@ A copy of the GNU General Public License is available on the World Wide
 Web at &lt;http://www.gnu.org/copyleft/gpl.html>. You can also obtain it by
 writing to the Free Software Foundation, Inc., 59 Temple Place - Suite
 330, Boston, MA 02111-1307, USA."/>
-    <Version Major="1"/>
+    <Version Major="1" Release="1" Build="1"/>
     <Files Count="6">
       <Item1>
         <Filename Value="frmlazpackageroptionsdeb.pas"/>
-        <UnitName Value="frmlazpackageroptionsdeb"/>
+        <UnitName Value="frmLazPackagerOptionsDeb"/>
       </Item1>
       <Item2>
         <Filename Value="lazpackagermain.pas"/>
@@ -58,7 +53,6 @@ writing to the Free Software Foundation, Inc., 59 Temple Place - Suite
         <UnitName Value="LazPackagerDebian"/>
       </Item6>
     </Files>
-    <Type Value="DesignTime"/>
     <RequiredPkgs Count="4">
       <Item1>
         <PackageName Value="SynEdit"/>

--- a/lazpackager.lpk
+++ b/lazpackager.lpk
@@ -25,7 +25,7 @@ A copy of the GNU General Public License is available on the World Wide
 Web at &lt;http://www.gnu.org/copyleft/gpl.html>. You can also obtain it by
 writing to the Free Software Foundation, Inc., 59 Temple Place - Suite
 330, Boston, MA 02111-1307, USA."/>
-    <Version Major="1" Release="1" Build="1"/>
+    <Version Major="1" Release="1" Build="3"/>
     <Files Count="6">
       <Item1>
         <Filename Value="frmlazpackageroptionsdeb.pas"/>

--- a/lazpackagerbase.pas
+++ b/lazpackagerbase.pas
@@ -266,10 +266,11 @@ var
   Tool: TIDEExternalToolOptions;
 begin
   Tool := TIDEExternalToolOptions.Create;
-  Tool.Filename := GetBuildScriptInterpreter;
+//  Tool.Filename := GetBuildScriptInterpreter;      // Filename: deprecated
+  Tool.Executable := GetBuildScriptInterpreter;
   Tool.CmdLineParams := GetBuildScriptName;
   Tool.WorkingDirectory := GetProjectPathAbsolute;
-  Tool.ShowAllOutput := True;
+//  Tool.ShowAllOutput := True;                   // ShowAllOutput: "Error: ID no member"
   RunExternalTool(Tool);
   Tool.Free;
   Self.Free;

--- a/lazpackagerbase.pas
+++ b/lazpackagerbase.pas
@@ -87,7 +87,7 @@ uses
   sysutils,
   Forms,
   LCLProc,
-  FileUtil,
+  FileUtil, LazStringUtils, LazFileUtils,
   LazIDEIntf,
   ProjectResourcesIntf,
   MacroIntf,


### PR DESCRIPTION
Made LazPackager compilable again with fpc & Lazarus stable versions (2.6.4 and 1.4.2)
- "Tool.ShowAllOutput = true" commented (err: ID no member)
- Tool.Filename -> Tool.Executable ("Filename" is deprecated)
  I let those comments in src code ATM, so upstream could easily find them if needed.
- Incremented the pkg release version. 1.0.1.1 now.

This is a very useful and interesting project, please feel free to tell if you need help (testing etc..) ;)
